### PR TITLE
moved to setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-gymnasium==0.28.1
-matplotlib==3.9.2
-moviepy==1.0.3
-numpy==1.24.1
-pandas==1.5.3
-pipreqs==0.4.13
-scipy==1.14.1
-seaborn==0.13.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+import os
+import sys
+from pathlib import Path
+
+from setuptools import Extension, setup, find_packages
+package_dir = os.path.join(os.path.dirname(__file__))
+setup(
+    name="rl",
+    version="0.0.1",
+    packages=find_packages(
+        include=["rl", "rl.*"]
+    ),
+    package_dir={"": package_dir},
+    zip_safe=False,
+    install_requires=["numpy","moviepy", "matplotlib", "pandas", "scipy", "seaborn","gymnasium","pipreqs"],
+    python_requires=">=3.7",
+)


### PR DESCRIPTION
Moved to setup.py. After instantiating the venv, you can call 
pip install -e . 
which will install the necessary modules + the module rl. Additionally, you can contain functions within the imported rl module by modifyinf the rl/__init__.py i.e.

rl/
|
|->subfolder/
    |
    |->subfile.py
from .subfolder.subfile import function
which after installing you can call from a script like rl.function()